### PR TITLE
Fix some build problems I ran into

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
-	<classpathentry kind="lib" path="lib/bcprov-jdk15on-147.jar"/>
+	<classpathentry kind="lib" path="lib/bcprov-jdk15on-148.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Largely based on BackupManagerService.java from AOSP.
 
 Usage: 
 
+Download the latest version of Bouncy Castle Provider jar 
+(```bcprov-jdk15on-148.jar```) from here:
+
+http://www.bouncycastle.org/latest_releases.html
+
 Drop the latest Bouncy Castle jar in lib/, import in Eclipse and adjust 
 build path if necessary. Use the abe.sh script to start the utility. 
 Syntax: 

--- a/abe.sh
+++ b/abe.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 JAVA=/usr/local/jdk1.7.0_04/bin/java
-BC=./lib/bcprov-jdk15on-147.jar
+BC=./lib/bcprov-jdk15on-148.jar
 CP=:bin:$BC
 
 "$JAVA" -cp $CP org.nick.abe.Main $*

--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,7 @@
 			<fileset dir="build" includes="**/*" />
 		</delete>
 		<mkdir dir="build" />
-		<javac srcdir="src" destdir="build" classpath="lib/bcprov-jdk15on-147.jar" debug="true" includeantruntime="false" encoding="UTF-8" source="1.7" />
+		<javac srcdir="src" destdir="build" classpath="lib/bcprov-jdk15on-148.jar" debug="true" includeantruntime="false" encoding="UTF-8" source="1.7" />
 	</target>
 
 	<target name="jar" depends="build" description="Create a standalone-jar (no external dependency)">
@@ -23,7 +23,7 @@
 			</manifest>
 			<fileset dir="build" />
 			<!-- Include BouncyCastle JAR -->
-			<zipfileset src="lib/bcprov-jdk15on-147.jar" includes="org/**" />
+			<zipfileset src="lib/bcprov-jdk15on-148.jar" includes="org/**" />
 		</jar>
 	</target>
 </project>


### PR DESCRIPTION
1. Add `source="1.7"` to `build.xml` to because the source code requires Java 7 (e.g. `DeflaterOutputStream`).
2. Upgrade `build.xml` and `README.md` to use Bouncy Castle 1.48.
3. Change `build.xml`'s output directory from `build` to `bin` so `abe.sh`'s classpath will work correctly (and match Eclipse's `bin` output directory structure).

If you would like me to change or remove any of these commits, just let me know and I can split them into separate pull requests.

Thanks! Your android-backup-extractor was a lifesaver! :+1:
