### PR TITLE
ask for a password if none was given and the backup is encrypted

### DIFF
--- a/src/org/nick/abe/AndroidBackup.java
+++ b/src/org/nick/abe/AndroidBackup.java
@@ -2,6 +2,7 @@
 package org.nick.abe;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Console;
 import java.io.DataOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -83,8 +84,14 @@ public class AndroidBackup {
             if (encryptionAlg.equals(ENCRYPTION_ALGORITHM_NAME)) {
                 isEncrypted = true;
                 if (password == null || "".equals(password)) {
-                    throw new IllegalArgumentException(
-                            "Backup encrypted but password not specified");
+                    Console console = System.console();
+                    if (console != null) {
+                        System.out.println("This backup is encrypted, please provide the password");
+                        password = new String(console.readPassword("Password: "));
+                    } else {
+                        throw new IllegalArgumentException(
+                                "Backup encrypted but password not specified");
+                    }
                 }
 
                 String userSaltHex = readHeaderLine(rawInStream); // 5


### PR DESCRIPTION
To avoid that you have to enter the password in the commandline and to think of it before you run abe.

Just in case abe is required to run on really old JVMs: This will require Java 1.6 or later to compile because System.console() was not available before.
