### PR TITLE
Update to latest bouncy castle release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Largely based on BackupManagerService.java from AOSP.
 Usage (Eclipse): 
 
 Download the latest version of Bouncy Castle Provider jar 
-(```bcprov-jdk15on-150.jar```) from here:
+(```bcprov-jdk15on-152.jar```) from here:
 
 http://www.bouncycastle.org/latest_releases.html
 

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 
 	<property name="jar.filename" value="abe.jar" />
 	<property name="main.class" value="org.nick.abe.Main" />
-	<property name="bcprov.jar" value="lib/bcprov-jdk15on-150.jar" />
+	<property name="bcprov.jar" value="lib/bcprov-jdk15on-152.jar" />
 
 
 	<target name="all" depends="build,jar" />


### PR DESCRIPTION
Looks like there have been a couple of releases since the docs were last updated. This version works for me, tried on an encrypted backup without issues.
