### PR TITLE
Warn if encryption is used but the available keysize seems too small

### DIFF
--- a/src/org/nick/abe/AndroidBackup.java
+++ b/src/org/nick/abe/AndroidBackup.java
@@ -83,6 +83,12 @@ public class AndroidBackup {
 
             if (encryptionAlg.equals(ENCRYPTION_ALGORITHM_NAME)) {
                 isEncrypted = true;
+
+                if (Cipher.getMaxAllowedKeyLength("AES") < MASTER_KEY_SIZE) {
+                    System.out.println("WARNING: Maximum allowed key-length seems smaller than needed. " +
+                            "Please check that unlimited strength cryptography is available, see README.md for details");
+                }
+
                 if (password == null || "".equals(password)) {
                     Console console = System.console();
                     if (console != null) {


### PR DESCRIPTION
This warning is a bit more obvious than just the "InvalidKeyException"
you get when you try to decrypt without unlimited jcepolicy.