### PR TITLE
Add important notes about packing tar archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,24 @@ Use gradle to create an all-in-one jar:
 
 ```java -jar build/libs/abe-all.jar pack|unpack|pack-kk [parameters as above]```
 
-More details about the backup format and the tool implementation in the 
-associated blog post: 
+# Notes
 
-http://nelenkov.blogspot.com/2012/06/unpacking-android-backups.html
+More details about the backup format and the tool implementation in the [associated blog post](https://nelenkov.blogspot.de/2012/06/unpacking-android-backups.html).
 
+### Packing tar archives
+
+- Android is **very** special about the order of files in the tar archive. The format is [described here](https://android.googlesource.com/platform/frameworks/base/+/4a627c71ff53a4fca1f961f4b1dcc0461df18a06).
+- Incompatible tar archives lead to errors or even system crashes.
+- Apps with the `allowBackup` flag set to `false` are [not backed up nor restored](https://android.googlesource.com/platform/frameworks/base/+/a858cb075d0c87e2965d401656ff2d5bc16406da).
+  - *(you can try restoring manually via `adb push` and `adb shell`)*
+- Errors are only printed to logcat, look out for `BackupManagerService`.
+
+The safest way to pack a tar archive is to get the list of files from the original backup.tar file:
+```shell
+tar tf backup.tar | grep -F "com.package.name" > package.list
+```
+And then use that list to build the tar file. In the extracted backup directory:
+```shell
+tar cf restore.tar -T package.list
+```
+You can now pack `restore.tar` and try `adb restore restore.ab`


### PR DESCRIPTION
I hope this makes sure people notice android is crazy about it, and hopefully save people a few hours of research why their backup is not restored. (see for example #37)